### PR TITLE
log viewer&task node orchestration

### DIFF
--- a/plugins/orion/src/components/workflow/WorkFlowDetail.tsx
+++ b/plugins/orion/src/components/workflow/WorkFlowDetail.tsx
@@ -2,12 +2,39 @@ import { ParodosPage } from '../ParodosPage';
 import { ContentHeader, SupportButton } from '@backstage/core-components';
 import { Chip, Typography } from '@material-ui/core';
 import { WorkFlowLogViewer } from './WorkFlowLogViewer';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { WorkFlowStepper } from './topology/WorkFlowStepper';
 import { useParams } from 'react-router-dom';
+import { WorkFlowTask } from './topology/type/WorkFlowTask';
+import { mockTasks } from './topology/mock/mockTasks';
+import { mockLog } from './topology/mock/mockLog';
 
 export const WorkFlowDetail = ({ isNew }: { isNew: boolean }) => {
   const { executionId } = useParams();
+  const [selectedTask, setSelectedTask] = useState<string | null>('');
+  const [allTasks, setAllTasks] = useState<WorkFlowTask[]>([]);
+  const [log, setLog] = useState<string>(``);
+
+  useEffect(() => {
+    setAllTasks([]);
+    const getWholeWorkflowExecutionInfo = () => {
+      // TODO api call to get subsequent execution CHAIN detail
+      setAllTasks(mockTasks);
+    };
+    getWholeWorkflowExecutionInfo();
+  }, [executionId]);
+
+  useEffect(() => {
+    const getSelectedTaskLog = () => {
+      // TODO  api call to get a task log from Workflow Execution Id
+      if (selectedTask !== '')
+        setLog(
+          `checking logs for ${selectedTask?.toUpperCase()} in execution: ${executionId}\n${mockLog}`,
+        );
+    };
+    getSelectedTaskLog();
+  }, [executionId, selectedTask]);
+
   return (
     <ParodosPage>
       {isNew && <Chip label="New application" color="secondary" />}
@@ -17,8 +44,10 @@ export const WorkFlowDetail = ({ isNew }: { isNew: boolean }) => {
       <Typography paragraph>
         You are onboarding: org-name/new-project. Execution Id is {executionId}
       </Typography>
-      <WorkFlowStepper />
-      <WorkFlowLogViewer />
+      {allTasks.length > 0 && (
+        <WorkFlowStepper tasks={allTasks} setSelectedTask={setSelectedTask} />
+      )}
+      {log !== '' && <WorkFlowLogViewer log={log} />}
     </ParodosPage>
   );
 };

--- a/plugins/orion/src/components/workflow/WorkFlowLogViewer.tsx
+++ b/plugins/orion/src/components/workflow/WorkFlowLogViewer.tsx
@@ -2,23 +2,6 @@ import { LogViewer } from '@backstage/core-components';
 import React from 'react';
 import { withStyles } from '@material-ui/core';
 
-const exampleLog = `Starting up task with following steps
-[32minfo[39m: green 1
-[32minfo[39m: green 2
-[32minfo[39m: green 3
-[31merror[39m: red 1
-[31merror[39m: red 2
-[31merror[39m: red 3
-[33merror[39m: yellow 1
-[33merror[39m: yellow 2
-[33merror[39m: yellow 3
-[34merror[39m: blue 1
-[34merror[39m: blue 2
-[34merror[39m: blue 3
-[35merror[39m: purple 1
-[36merror[39m: cyan 1
-`;
-
 const ParodosLogViewer = withStyles(theme => ({
   root: {
     background: theme.palette.background.paper,
@@ -30,8 +13,8 @@ const ParodosLogViewer = withStyles(theme => ({
   },
 }))(LogViewer);
 
-export const WorkFlowLogViewer = () => (
+export const WorkFlowLogViewer = ({ log }: { log: string }) => (
   <div style={{ height: '43%' }}>
-    <ParodosLogViewer text={exampleLog} />
+    <ParodosLogViewer text={log} />
   </div>
 );

--- a/plugins/orion/src/components/workflow/topology/PipelineLayout.tsx
+++ b/plugins/orion/src/components/workflow/topology/PipelineLayout.tsx
@@ -22,6 +22,7 @@ import '@patternfly/react-styles/css/components/Topology/topology-components.css
 import pipelineComponentFactory from './pipelineComponentFactory';
 import { useDemoPipelineNodes } from './useDemoPipelineNodes';
 import { GROUPED_PIPELINE_NODE_SEPARATION_HORIZONTAL } from './DemoTaskGroupEdge';
+import { WorkFlowTask } from './type/WorkFlowTask';
 
 export const PIPELINE_NODE_SEPARATION_VERTICAL = 10;
 
@@ -30,11 +31,16 @@ export const LAYOUT_TITLE = 'Layout';
 const PIPELINE_LAYOUT = 'PipelineLayout';
 const GROUPED_PIPELINE_LAYOUT = 'GroupedPipelineLayout';
 
-const TopologyPipelineLayout: React.FC = () => {
+type Props = {
+  tasks: WorkFlowTask[];
+  setSelectedTask: (selectedTask: string) => void;
+};
+
+const TopologyPipelineLayout = (props: Props) => {
   const [selectedIds, setSelectedIds] = React.useState<string[]>();
 
   const controller = useVisualizationController();
-  const pipelineNodes = useDemoPipelineNodes(false, false, false, false);
+  const pipelineNodes = useDemoPipelineNodes(props.tasks);
 
   React.useEffect(() => {
     const spacerNodes = getSpacerNodes(pipelineNodes);
@@ -68,6 +74,7 @@ const TopologyPipelineLayout: React.FC = () => {
 
   useEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
     setSelectedIds(ids);
+    props.setSelectedTask(ids.toString());
   });
 
   return (
@@ -79,7 +86,7 @@ const TopologyPipelineLayout: React.FC = () => {
 
 TopologyPipelineLayout.displayName = 'TopologyPipelineLayout';
 
-export const PipelineLayout = React.memo(() => {
+export const PipelineLayout = React.memo((props: Props) => {
   const controller = new Visualization();
   controller.setFitToScreenOnLayout(true);
   controller.registerComponentFactory(pipelineComponentFactory);
@@ -92,7 +99,6 @@ export const PipelineLayout = React.memo(() => {
             ? GROUPED_PIPELINE_NODE_SEPARATION_HORIZONTAL
             : GROUPED_PIPELINE_NODE_SEPARATION_HORIZONTAL,
         ignoreGroups: true,
-        // nodeDistance: -20,
       }),
   );
   controller.fromModel(
@@ -113,7 +119,7 @@ export const PipelineLayout = React.memo(() => {
 
   return (
     <VisualizationProvider controller={controller}>
-      <TopologyPipelineLayout />
+      <TopologyPipelineLayout {...props} />
     </VisualizationProvider>
   );
 });

--- a/plugins/orion/src/components/workflow/topology/TopologyComponent.css
+++ b/plugins/orion/src/components/workflow/topology/TopologyComponent.css
@@ -1,4 +1,0 @@
-.pf-ri__topology-demo {
-  width: 100%;
-  height: 35%;
-}

--- a/plugins/orion/src/components/workflow/topology/WorkFlowStepper.tsx
+++ b/plugins/orion/src/components/workflow/topology/WorkFlowStepper.tsx
@@ -2,27 +2,29 @@ import React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
 import { PipelineLayout } from './PipelineLayout';
 
-import './TopologyComponent.css';
+import { makeStyles } from '@material-ui/core';
+import { WorkFlowTask } from './type/WorkFlowTask';
 
-export const WorkFlowStepper = () => {
+const useStyles = makeStyles(theme => ({
+  pfRi__topologyDemo: {
+    width: '100%',
+    height: '35%',
+    '& .pf-topology-visualization-surface__svg': {
+      background: theme.palette.background.default,
+    },
+  },
+}));
+
+type Props = {
+  tasks: WorkFlowTask[];
+  setSelectedTask: (selectedTask: string) => void;
+};
+
+export const WorkFlowStepper = (props: Props) => {
+  const classes = useStyles();
   return (
-    <div className="pf-ri__topology-demo">
-      <PipelineLayout />
+    <div className={classes.pfRi__topologyDemo}>
+      <PipelineLayout {...props} />
     </div>
   );
 };
-
-// export const WorkFlowStepper = () => {
-//   return (
-//       <ParodosPage>
-//           <ContentHeader title="Onboarding">
-//               <SupportButton title="Need help?">Lorem Ipsum</SupportButton>
-//           </ContentHeader>
-//           <Typography paragraph>
-//               You are onboarding: org-name/new-project
-//           </Typography>
-//           <TopologyContentBody/>
-//           <WorkFlowLogViewer/>
-//       </ParodosPage>
-//   );
-// };

--- a/plugins/orion/src/components/workflow/topology/mock/mockLog.ts
+++ b/plugins/orion/src/components/workflow/topology/mock/mockLog.ts
@@ -1,0 +1,16 @@
+export const mockLog = `Starting up task with following steps
+[32minfo[39m: green 1
+[32minfo[39m: green 2
+[32minfo[39m: green 3
+[31merror[39m: red 1
+[31merror[39m: red 2
+[31merror[39m: red 3
+[33mwarning[39m: yellow 1
+[33mwarning[39m: yellow 2
+[33mwarning[39m: yellow 3
+[34merror[39m: blue 1
+[34merror[39m: blue 2
+[34merror[39m: blue 3
+[35merror[39m: purple 1
+[36merror[39m: cyan 1
+`;

--- a/plugins/orion/src/components/workflow/topology/mock/mockTasks.ts
+++ b/plugins/orion/src/components/workflow/topology/mock/mockTasks.ts
@@ -62,3 +62,30 @@ export const mockTasks: WorkFlowTask[] = [
     runAfterTasks: [],
   },
 ];
+
+export const mockTasks2: WorkFlowTask[] = [
+  {
+    id: `project-information`,
+    type: DEFAULT_TASK_NODE_TYPE,
+    label: `Project Information`,
+    status: 'completed',
+    locked: false,
+    runAfterTasks: [],
+  },
+  {
+    id: `SSL Certification`,
+    type: DEFAULT_TASK_NODE_TYPE,
+    label: `SSL Certification`,
+    status: 'in_progress',
+    locked: false,
+    runAfterTasks: [`project-information`],
+  },
+  {
+    id: `AD Groups`,
+    type: DEFAULT_TASK_NODE_TYPE,
+    label: `AD Groups`,
+    status: 'completed',
+    locked: false,
+    runAfterTasks: [`project-information`],
+  },
+];

--- a/plugins/orion/src/components/workflow/topology/useDemoPipelineNodes.tsx
+++ b/plugins/orion/src/components/workflow/topology/useDemoPipelineNodes.tsx
@@ -5,9 +5,8 @@ import {
   WhenStatus,
 } from '@patternfly/react-topology';
 import '@patternfly/react-styles/css/components/Topology/topology-components.css';
-import { mockTasks } from './mock/mockTasks';
 import LockIcon from '@material-ui/icons/Lock';
-import './TopologyComponent.css';
+import { WorkFlowTask } from './type/WorkFlowTask';
 
 export const NODE_PADDING_VERTICAL = 15;
 export const NODE_PADDING_HORIZONTAL = 10;
@@ -16,10 +15,7 @@ export const DEFAULT_TASK_WIDTH = 200;
 export const DEFAULT_TASK_HEIGHT = 30;
 
 export const useDemoPipelineNodes = (
-  showContextMenu: boolean,
-  showBadges: boolean,
-  showIcons: boolean,
-  badgeTooltips: boolean,
+  workflowTasks: WorkFlowTask[],
 ): PipelineNodeModel[] =>
   React.useMemo(() => {
     const getStatus: any = (status: string) => {
@@ -35,22 +31,16 @@ export const useDemoPipelineNodes = (
     };
 
     // Create a task node for each task status
-    const tasks = mockTasks.map(workFlowTask => {
+    const tasks = workflowTasks.map(workFlowTask => {
       // Set all the standard fields
       const task: PipelineNodeModel = {
         id: workFlowTask.id,
         type: workFlowTask.type,
         label: workFlowTask.label,
-        width:
-          DEFAULT_TASK_WIDTH +
-          (showContextMenu ? 10 : 0) +
-          (showBadges ? 40 : 0),
+        width: DEFAULT_TASK_WIDTH,
         height: DEFAULT_TASK_HEIGHT,
         style: {
-          padding: [
-            NODE_PADDING_VERTICAL,
-            NODE_PADDING_HORIZONTAL + (showIcons ? 25 : 0),
-          ],
+          padding: [NODE_PADDING_VERTICAL, NODE_PADDING_HORIZONTAL + 25],
         },
         runAfterTasks: workFlowTask.runAfterTasks,
       };
@@ -58,12 +48,7 @@ export const useDemoPipelineNodes = (
       // put options in data, our DEMO task node will pass them along to the TaskNode
       task.data = {
         status: getStatus(workFlowTask.status),
-        badge: showBadges ? '3/4' : undefined,
-        badgeTooltips,
         taskIcon: workFlowTask.locked ? <LockIcon color="error" /> : null,
-        taskIconTooltip: showIcons ? 'Environment' : undefined,
-        showContextMenu,
-        // columnGroup: index % STATUS_PER_ROW
       };
 
       return task;
@@ -75,5 +60,5 @@ export const useDemoPipelineNodes = (
       task.data.whenStatus = getConditionMet(task.data.status);
     });
 
-    return [...tasks]; // , ...finallyNodes, finallyGroup];
-  }, [badgeTooltips, showBadges, showContextMenu, showIcons]);
+    return tasks;
+  }, [workflowTasks]);


### PR DESCRIPTION
1). topology background color is now same as the page background (dark theme compatible)
2)
beginning of detail page:
<img width="1387" alt="Screenshot 2023-02-28 at 12 19 23 PM" src="https://user-images.githubusercontent.com/58698556/221928846-ceba4031-8433-48b0-ac6e-d167701bf31c.png">

after select a task node (execution id is hard coded as undefined,  it will show up when real value passed in):
<img width="1386" alt="Screenshot 2023-02-28 at 12 19 31 PM" src="https://user-images.githubusercontent.com/58698556/221929152-14eea507-8ceb-4558-9071-97b0203de84f.png">
