### PR TITLE
ErrorMessage component for different error display depending on NODE_ENV

### DIFF
--- a/plugins/orion/src/components/ParodosPage.tsx
+++ b/plugins/orion/src/components/ParodosPage.tsx
@@ -14,6 +14,8 @@ import {
 } from './icons';
 import { ProjectType } from './types';
 import { useBackendUrl } from './api';
+import useAsync from 'react-use/lib/useAsync';
+import { ErrorMessage } from './errors/ErrorMessage';
 
 export const pluginRoutePrefix = '/parodos';
 
@@ -65,21 +67,14 @@ export const ParodosPage: React.FC = ({ children }) => {
   const [isProject, setIsProject] = React.useState(true);
   const backendUrl = useBackendUrl();
 
-  React.useEffect(() => {
-    const doItAsync = async () => {
-      try {
-        const response = await fetch(
-          `${backendUrl}/api/proxy/parodos/projects`,
-        );
-        const receivedProjects = (await response.json()) as ProjectType[];
-        setIsProject(receivedProjects.length > 0);
-      } catch (e) {
-        setIsProject(false);
-        // TODO: render error
-      }
-    };
-    doItAsync();
-  }, [setIsProject, backendUrl]);
+  const { error} = useAsync(async () => {
+    const response = await fetch(
+      `${backendUrl}/api/proxy/parodos/projects`,
+    );
+
+    const receivedProjects = (await response.json()) as ProjectType[];
+    setIsProject(receivedProjects.length > 0);
+  }, []);
 
   React.useEffect(() => {
     const index =
@@ -97,6 +92,7 @@ export const ParodosPage: React.FC = ({ children }) => {
   return (
     <Page themeId="tool">
       <PageHeader />
+      {error && <ErrorMessage error={error}/>}
       <HeaderTabs
         selectedIndex={selectedTab}
         onChange={onChangeTab}

--- a/plugins/orion/src/components/ParodosPage.tsx
+++ b/plugins/orion/src/components/ParodosPage.tsx
@@ -67,10 +67,8 @@ export const ParodosPage: React.FC = ({ children }) => {
   const [isProject, setIsProject] = React.useState(true);
   const backendUrl = useBackendUrl();
 
-  const { error} = useAsync(async () => {
-    const response = await fetch(
-      `${backendUrl}/api/proxy/parodos/projects`,
-    );
+  const { error } = useAsync(async () => {
+    const response = await fetch(`${backendUrl}/api/proxy/parodos/projects`);
 
     const receivedProjects = (await response.json()) as ProjectType[];
     setIsProject(receivedProjects.length > 0);
@@ -92,7 +90,7 @@ export const ParodosPage: React.FC = ({ children }) => {
   return (
     <Page themeId="tool">
       <PageHeader />
-      {error && <ErrorMessage error={error}/>}
+      {error && <ErrorMessage error={error} />}
       <HeaderTabs
         selectedIndex={selectedTab}
         onChange={onChangeTab}

--- a/plugins/orion/src/components/errors/ErrorMessage.tsx
+++ b/plugins/orion/src/components/errors/ErrorMessage.tsx
@@ -4,21 +4,21 @@ import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
-export function ErrorMessage({error}: ErrorPanelProps): JSX.Element | null {
+export function ErrorMessage({ error }: ErrorPanelProps): JSX.Element | null {
   const errorApi = useApi(errorApiRef);
 
   useEffect(() => {
-    if(isDevelopment) {
+    if (isDevelopment) {
       return;
     }
 
     // simple error message to user
     errorApi.post(new Error('An error has occurred'));
-  }, [errorApi])
-  
-  if(!isDevelopment) {
+  }, [errorApi]);
+
+  if (!isDevelopment) {
     return null;
   }
 
-  return <ErrorPanel error={error} defaultExpanded/>
+  return <ErrorPanel error={error} defaultExpanded />;
 }

--- a/plugins/orion/src/components/errors/ErrorMessage.tsx
+++ b/plugins/orion/src/components/errors/ErrorMessage.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import { ErrorPanel, type ErrorPanelProps } from '@backstage/core-components';
+import { errorApiRef, useApi } from '@backstage/core-plugin-api';
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+export function ErrorMessage({error}: ErrorPanelProps): JSX.Element | null {
+  const errorApi = useApi(errorApiRef);
+
+  useEffect(() => {
+    if(isDevelopment) {
+      return;
+    }
+
+    // simple error message to user
+    errorApi.post(new Error('An error has occurred'));
+  }, [errorApi])
+  
+  if(!isDevelopment) {
+    return null;
+  }
+
+  return <ErrorPanel error={error} defaultExpanded/>
+}


### PR DESCRIPTION
The PR contains an `<ErrorMessage/>` component that will display a standard error message when `NODE_ENV=production`.

![user](https://user-images.githubusercontent.com/118328/222422418-2a38ddf7-69c6-4b8d-9b99-ed345d9c0958.png)

And a more detailed error message in development mode that I think is more readable than reading the console

![aaaa](https://user-images.githubusercontent.com/118328/222422535-064f421d-1f33-464a-910d-35e0ee9e360d.png)

I've replaced a vanilla `fetch` call with [react-use useAsync](https://github.com/streamich/react-use/blob/master/docs/useAsync.md), which backstage uses for all of its async calls and is pretty simple. 

It offers better error handling, a loading flag, etc., and is pretty simple.