### PR TITLE
list workflow options after the creation of an assessment

### DIFF
--- a/plugins/orion/.eslintrc.js
+++ b/plugins/orion/.eslintrc.js
@@ -1,1 +1,16 @@
-module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
+  rules: {
+    'react-hooks/rules-of-hooks': [
+      'error',
+      {
+        additionalHooks: '(useIsomorphicLayoutEffect|useAsync)',
+      },
+    ],
+    'react-hooks/exhaustive-deps': [
+      'error',
+      {
+        additionalHooks: '(useIsomorphicLayoutEffect|useAsyncFn)',
+      },
+    ],
+  },
+});

--- a/plugins/orion/.eslintrc.js
+++ b/plugins/orion/.eslintrc.js
@@ -3,13 +3,13 @@ module.exports = require('@backstage/cli/config/eslint-factory')(__dirname, {
     'react-hooks/rules-of-hooks': [
       'error',
       {
-        additionalHooks: '(useIsomorphicLayoutEffect|useAsync)',
+        additionalHooks: '(useAsync|useAsync)',
       },
     ],
     'react-hooks/exhaustive-deps': [
       'error',
       {
-        additionalHooks: '(useIsomorphicLayoutEffect|useAsyncFn)',
+        additionalHooks: '(useAsync|useAsyncFn)',
       },
     ],
   },

--- a/plugins/orion/src/components/ParodosPage.tsx
+++ b/plugins/orion/src/components/ParodosPage.tsx
@@ -83,7 +83,7 @@ export const ParodosPage: React.FC<ParodosPageProps> = ({
 
     const receivedProjects = (await response.json()) as ProjectType[];
     setIsProject(receivedProjects.length > 0);
-  }, []);
+  }, [backendUrl]);
 
   React.useEffect(() => {
     let index = navigationMap.findIndex(({ routes }) =>

--- a/plugins/orion/src/components/ParodosPage.tsx
+++ b/plugins/orion/src/components/ParodosPage.tsx
@@ -17,6 +17,7 @@ import { useBackendUrl } from './api';
 import useAsync from 'react-use/lib/useAsync';
 import { ErrorMessage } from './errors/ErrorMessage';
 import { useNavigate } from 'react-router-dom';
+import * as urls from '../urls';
 
 export const pluginRoutePrefix = '/parodos';
 
@@ -78,7 +79,7 @@ export const ParodosPage: React.FC<ParodosPageProps> = ({
   const navigate = useNavigate();
 
   const { error } = useAsync(async () => {
-    const response = await fetch(`${backendUrl}/api/proxy/parodos/projects`);
+    const response = await fetch(`${backendUrl}${urls.Projects}`);
 
     const receivedProjects = (await response.json()) as ProjectType[];
     setIsProject(receivedProjects.length > 0);

--- a/plugins/orion/src/components/PluginRouter.tsx
+++ b/plugins/orion/src/components/PluginRouter.tsx
@@ -19,7 +19,7 @@ export const PluginRouter = () => (
     <Route path="/training" element={<Training />} />
     <Route path="/metrics" element={<Metrics />} />
     <Route
-      path="/onboarding/:projectId/:workflowname/new/"
+      path="/onboarding/:projectId/:workflowName/new/"
       element={<Onboarding isNew />}
     />
     <Route

--- a/plugins/orion/src/components/PluginRouter.tsx
+++ b/plugins/orion/src/components/PluginRouter.tsx
@@ -19,7 +19,7 @@ export const PluginRouter = () => (
     <Route path="/training" element={<Training />} />
     <Route path="/metrics" element={<Metrics />} />
     <Route
-      path="/onboarding/:projectId/:workflowId/new/"
+      path="/onboarding/:projectId/:workflowname/new/"
       element={<Onboarding isNew />}
     />
     <Route

--- a/plugins/orion/src/components/projectOverview/ProjectOverview.tsx
+++ b/plugins/orion/src/components/projectOverview/ProjectOverview.tsx
@@ -64,7 +64,7 @@ export const ProjectOverviewPage = (): JSX.Element => {
     const result = receivedProjects.map(project => ({ ...project, status }));
 
     return result;
-  }, []);
+  }, [backendUrl]);
 
   React.useEffect(() => {
     if (!allProjects) {

--- a/plugins/orion/src/components/projectOverview/ProjectOverview.tsx
+++ b/plugins/orion/src/components/projectOverview/ProjectOverview.tsx
@@ -9,7 +9,7 @@ import {
 import Add from '@material-ui/icons/Add';
 import { Card, CardContent, Grid, makeStyles } from '@material-ui/core';
 import { useAsync } from 'react-use';
-
+import * as urls from '../../urls';
 import { EmptyProjectsState } from './EmptyProjectsState';
 import { ParodosPage } from '../ParodosPage';
 import { ProjectStatusType, ProjectType } from '../types';
@@ -55,9 +55,8 @@ export const ProjectOverviewPage = (): JSX.Element => {
     error: errorProjects,
   } = useAsync(async (): Promise<ProjectType[]> => {
     // TODO: finish after https://issues.redhat.com/browse/FLPATH-131
-    // return mockProjects;
 
-    const response = await fetch(`${backendUrl}/api/proxy/parodos/projects`);
+    const response = await fetch(`${backendUrl}${urls.Projects}`);
     const receivedProjects = (await response.json()) as ProjectType[];
 
     // mock status for now:

--- a/plugins/orion/src/components/workflow/Workflow.tsx
+++ b/plugins/orion/src/components/workflow/Workflow.tsx
@@ -70,25 +70,25 @@ export function Workflow(): JSX.Element {
       });
 
       const workflow = workflowSchema.parse(await workFlowResponse.json());
-      
-      
+
       const options = displayableWorkflowOptions.flatMap(option => {
         const items = workflow.workFlowOptions[option];
-        
+
         if (items.length === 0) {
           return items;
         }
-        
+
         const optionType = option
-        .replace(/([a-z])([A-Z])/g, '$1 $2')
-        .toUpperCase();
-        
+          .replace(/([a-z])([A-Z])/g, '$1 $2')
+          .split(' ')[0]
+          .toUpperCase();
+
         return items.map(item => ({
           ...item,
           type: optionType,
         }));
       }) as WorkflowOptionsListItem[];
-      
+
       setWorkflowOptions(options);
 
       setAssessmentStatus('complete');

--- a/plugins/orion/src/components/workflow/WorkflowDefinitions.tsx
+++ b/plugins/orion/src/components/workflow/WorkflowDefinitions.tsx
@@ -10,12 +10,10 @@ import {
   Typography,
 } from '@material-ui/core';
 import React from 'react';
-import {
-  type WorkflowDefinition,
-  type Project,
-} from '../../models/workflowDefinitionSchema';
+import { type WorkflowDefinition } from '../../models/workflowDefinitionSchema';
 import { useCommonStyles } from '../../styles';
 import { Link } from 'react-router-dom';
+import { type Project } from '../../models/project';
 
 interface WorkflowDefinitionsProps {
   project: Project;
@@ -32,6 +30,7 @@ const useStyles = makeStyles(theme => ({
   },
   applicationCard: {
     background: theme.palette.background.default,
+    color: theme.palette.text.secondary,
     height: '100%',
   },
 }));

--- a/plugins/orion/src/components/workflow/WorkflowOptionsList.tsx
+++ b/plugins/orion/src/components/workflow/WorkflowOptionsList.tsx
@@ -55,6 +55,7 @@ export function WorkflowOptionsList({
           <Grid item xs={12} lg={6} xl={4} key={workflowOption.identifier}>
             <Card raised={false} className={styles.applicationCard}>
               <CardMedia>
+                <CardContent>{workflowOption.type}</CardContent>
                 <ItemCardHeader
                   title={workflowOption.displayName}
                   classes={{ root: styles.applicationHeader }}

--- a/plugins/orion/src/components/workflow/WorkflowOptionsList.tsx
+++ b/plugins/orion/src/components/workflow/WorkflowOptionsList.tsx
@@ -10,14 +10,16 @@ import {
   Typography,
 } from '@material-ui/core';
 import React from 'react';
-import { type WorkflowDefinition } from '../../models/workflowDefinitionSchema';
 import { useCommonStyles } from '../../styles';
 import { Link } from 'react-router-dom';
 import { type Project } from '../../models/project';
+import { type WorkflowOptionItem } from '../../models/workflow';
 
-interface WorkflowDefinitionsProps {
+export type WorkflowOptionsListItem = WorkflowOptionItem & { type: string };
+
+interface WorkflowOptionsListProps {
   project: Project;
-  workflowDefinitions: WorkflowDefinition[];
+  workflowOptions: WorkflowOptionsListItem[];
 }
 
 const useStyles = makeStyles(theme => ({
@@ -35,10 +37,10 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export function WorkflowDefinitions({
+export function WorkflowOptionsList({
   project,
-  workflowDefinitions,
-}: WorkflowDefinitionsProps): JSX.Element {
+  workflowOptions,
+}: WorkflowOptionsListProps): JSX.Element {
   const commonStyles = useCommonStyles();
   const styles = useStyles();
 
@@ -49,27 +51,22 @@ export function WorkflowDefinitions({
         option(s):
       </Typography>
       <Grid container direction="row" spacing={2}>
-        {workflowDefinitions.map(workflow => (
-          <Grid item xs={12} lg={6} xl={4} key={workflow.id}>
-            <Card
-              raised={false}
-              key={workflow.name}
-              className={styles.applicationCard}
-            >
+        {workflowOptions.map(workflowOption => (
+          <Grid item xs={12} lg={6} xl={4} key={workflowOption.identifier}>
+            <Card raised={false} className={styles.applicationCard}>
               <CardMedia>
                 <ItemCardHeader
-                  title={workflow.name}
+                  title={workflowOption.displayName}
                   classes={{ root: styles.applicationHeader }}
                 />
               </CardMedia>
-              <CardContent>{workflow.description}</CardContent>
+              <CardContent>{workflowOption.description}</CardContent>
               <CardActions>
                 <Button
-                  id={workflow.id}
                   variant="text"
                   color="primary"
                   component={Link}
-                  to={`/parodos/onboarding/${project?.id}/${workflow.id}/new/`}
+                  to={`/parodos/onboarding/${project?.id}/${workflowOption.workFlowName}/new/`}
                 >
                   START
                 </Button>

--- a/plugins/orion/src/components/workflow/constants.ts
+++ b/plugins/orion/src/components/workflow/constants.ts
@@ -1,0 +1,1 @@
+export const ASSESSMENT_WORKFLOW = 'onboardingAssessment_ASSESSMENT_WORKFLOW';

--- a/plugins/orion/src/components/workflow/onboarding/Onboarding.tsx
+++ b/plugins/orion/src/components/workflow/onboarding/Onboarding.tsx
@@ -97,7 +97,7 @@ export function Onboarding({ isNew }: OnboardingProps): JSX.Element {
         state: { isNew: isNew },
       });
     },
-    [workflow, projectId],
+    [workflow, projectId, backendUrl, navigate, isNew],
   );
 
   if (startWorkflowError) {

--- a/plugins/orion/src/components/workflow/onboarding/Onboarding.tsx
+++ b/plugins/orion/src/components/workflow/onboarding/Onboarding.tsx
@@ -44,18 +44,18 @@ const useStyles = makeStyles(theme => ({
 
 export function Onboarding({ isNew }: OnboardingProps): JSX.Element {
   const backendUrl = useBackendUrl();
-  const { workflowId, projectId } = useParams();
+  const { workflowName, projectId } = useParams();
   const styles = useStyles();
 
-  assert(!!workflowId, `no workflowId in Onboarding`);
+  assert(!!workflowName, `no workflowId in Onboarding`);
 
   const {
     loading,
     error,
     value: formSchema,
-  } = useWorkflowDefinitionToJsonSchema(workflowId, 'byId');
+  } = useWorkflowDefinitionToJsonSchema(workflowName, 'byName');
 
-  const { value: workflow } = useGetWorkflowDefinition(workflowId, 'byId');
+  const { value: workflow } = useGetWorkflowDefinition(workflowName, 'byName');
 
   const navigate = useNavigate();
 

--- a/plugins/orion/src/components/workflow/onboarding/Onboarding.tsx
+++ b/plugins/orion/src/components/workflow/onboarding/Onboarding.tsx
@@ -24,6 +24,7 @@ import { useBackendUrl } from '../../api/useBackendUrl';
 import { type IChangeEvent } from '@rjsf/core-v5';
 import { WorkflowExecuteResponseType } from '../../types';
 import { type RJSFValidationError } from '@rjsf/utils';
+import * as urls from '../../../urls';
 
 interface OnboardingProps {
   isNew: boolean;
@@ -68,7 +69,7 @@ export function Onboarding({ isNew }: OnboardingProps): JSX.Element {
 
       const payload = {
         projectId,
-        workFlowName: workflow.name || 'missing',
+        workFlowName: workflow.name,
         workFlowTasks: workflow.tasks.map(task => {
           return {
             name: task.name,
@@ -84,7 +85,7 @@ export function Onboarding({ isNew }: OnboardingProps): JSX.Element {
         }),
       };
 
-      const data = await fetch(`${backendUrl}/api/proxy/parodos/workflows`, {
+      const data = await fetch(`${backendUrl}${urls.Workflows}`, {
         method: 'POST',
         body: JSON.stringify(payload),
       });
@@ -109,13 +110,11 @@ export function Onboarding({ isNew }: OnboardingProps): JSX.Element {
       {!error && isNew && <Chip label="New application" color="secondary" />}
 
       {!error && (
-        <ContentHeader title={`${workflow?.name || '...'}`}>
+        <ContentHeader title={`${workflow?.name}`}>
           <SupportButton title="Need help?">Lorem Ipsum</SupportButton>
         </ContentHeader>
       )}
-      <Typography paragraph>
-        You are onboarding {workflow?.id || '...'}.
-      </Typography>
+      <Typography paragraph>You are onboarding {workflow?.name}.</Typography>
       {loading || (startWorkflowLoading && <Progress />)}
       {formSchema?.schema && (
         <InfoCard>

--- a/plugins/orion/src/components/workflow/useGetProjectAssessmentSchema.ts
+++ b/plugins/orion/src/components/workflow/useGetProjectAssessmentSchema.ts
@@ -13,7 +13,7 @@ export function useGetProjectAssessmentSchema(): AsyncState<FormSchema> {
 
   const cloned = JSON.parse(JSON.stringify(result.value));
 
-  // this should be coming from the API
+  // TODO: this should be coming from the API
   cloned.tasks[0].parameters.unshift({
     key: 'Name',
     description: 'New Project',

--- a/plugins/orion/src/components/workflow/useGetProjectAssessmentSchema.ts
+++ b/plugins/orion/src/components/workflow/useGetProjectAssessmentSchema.ts
@@ -2,30 +2,23 @@ import { type AsyncState } from 'react-use/lib/useAsync';
 import { useGetWorkflowDefinition } from '../../hooks/useGetWorkflowDefinitions';
 import { FormSchema } from '../types';
 import { jsonSchemaFromWorkflowDefinition } from '../../hooks/useWorkflowDefinitionToJsonSchema';
+import { ASSESSMENT_WORKFLOW } from './constants';
 
 export function useGetProjectAssessmentSchema(): AsyncState<FormSchema> {
-  // TODO: check this
-  const result = useGetWorkflowDefinition('ASSESSMENT', 'byType');
+  const result = useGetWorkflowDefinition(ASSESSMENT_WORKFLOW, 'byName');
 
   if (!result.value) {
     return { ...result, value: undefined };
   }
 
-  const cloned = { ...result.value };
+  const cloned = JSON.parse(JSON.stringify(result.value));
 
-  // not sure why this is not coming from the API
-  cloned.tasks.unshift({
-    id: 'project-name',
-    name: 'project-name',
-    parameters: [
-      {
-        key: 'Name',
-        description: 'New Project',
-        optional: false,
-        type: 'TEXT',
-      },
-    ],
-    outputs: [],
+  // this should be coming from the API
+  cloned.tasks[0].parameters.unshift({
+    key: 'Name',
+    description: 'New Project',
+    optional: false,
+    type: 'TEXT',
   });
 
   const formSchema = jsonSchemaFromWorkflowDefinition(cloned);

--- a/plugins/orion/src/hooks/useGetWorkflowDefinitions.ts
+++ b/plugins/orion/src/hooks/useGetWorkflowDefinitions.ts
@@ -25,11 +25,11 @@ const predicates = {
   byName: (workflow: WorkflowDefinition) => workflow.name,
 } as const;
 
-type Predicates = keyof typeof predicates;
+export type GetDefinitionFilter = keyof typeof predicates;
 
 export function useGetWorkflowDefinition(
   value: string,
-  filterBy: Predicates,
+  filterBy: GetDefinitionFilter,
 ): AsyncState<WorkflowDefinition> {
   const result = useGetWorkflowDefinitions();
 

--- a/plugins/orion/src/hooks/useGetWorkflowDefinitions.ts
+++ b/plugins/orion/src/hooks/useGetWorkflowDefinitions.ts
@@ -3,6 +3,7 @@ import { useBackendUrl } from '../components/api/useBackendUrl';
 import { assert } from 'assert-ts';
 import { WorkflowDefinition } from '../models/workflowDefinitionSchema';
 import { mockAndromedaWorkflowDefinition } from '../mocks/workflowDefinitions/andromeda';
+import * as urls from '../urls';
 
 export function useGetWorkflowDefinitions(): AsyncState<WorkflowDefinition[]> {
   const backendUrl = useBackendUrl();
@@ -10,9 +11,7 @@ export function useGetWorkflowDefinitions(): AsyncState<WorkflowDefinition[]> {
   return useAsync(async function getWorkflowDefinitions(): Promise<
     WorkflowDefinition[]
   > {
-    const response = await fetch(
-      `${backendUrl}/api/proxy/parodos/workflowdefinitions`,
-    );
+    const response = await fetch(`${backendUrl}${urls.WorkflowDefinitions}`);
 
     const workflowDefinitions = (await response.json()) as WorkflowDefinition[];
 
@@ -23,6 +22,7 @@ export function useGetWorkflowDefinitions(): AsyncState<WorkflowDefinition[]> {
 const predicates = {
   byId: (workflow: WorkflowDefinition) => workflow.id,
   byType: (workflow: WorkflowDefinition) => workflow.type,
+  byName: (workflow: WorkflowDefinition) => workflow.name,
 } as const;
 
 type Predicates = keyof typeof predicates;

--- a/plugins/orion/src/hooks/useWorkflowDefinitionToJsonSchema.ts
+++ b/plugins/orion/src/hooks/useWorkflowDefinitionToJsonSchema.ts
@@ -1,4 +1,7 @@
-import { useGetWorkflowDefinition } from './useGetWorkflowDefinitions';
+import {
+  GetDefinitionFilter,
+  useGetWorkflowDefinition,
+} from './useGetWorkflowDefinitions';
 import {
   type WorkFlowTaskParameterType,
   workflowDefinitionSchema,
@@ -119,7 +122,7 @@ export function jsonSchemaFromWorkflowDefinition(
 
 export function useWorkflowDefinitionToJsonSchema(
   workflowDefinition: string,
-  filterType: 'byId' | 'byType',
+  filterType: GetDefinitionFilter,
 ): AsyncState<FormSchema> {
   const result = useGetWorkflowDefinition(workflowDefinition, filterType);
 

--- a/plugins/orion/src/models/project.test.ts
+++ b/plugins/orion/src/models/project.test.ts
@@ -5,7 +5,7 @@ describe('project', () => {
     const result = projectSchema.safeParse({
       id: 'c6066cdd-9984-48a3-a08e-cc000a3f4d35',
       name: 'string',
-      description: 'string',
+      description: null,
       createDate: '2023-03-09T20:43:05.061+00:00',
       modifyDate: '2023-03-09T20:43:05.061+00:00',
       username: null,

--- a/plugins/orion/src/models/project.test.ts
+++ b/plugins/orion/src/models/project.test.ts
@@ -1,0 +1,16 @@
+import { Project, projectSchema } from './project';
+
+describe('project', () => {
+  it('parses the project response', () => {
+    const result = projectSchema.safeParse({
+      id: 'c6066cdd-9984-48a3-a08e-cc000a3f4d35',
+      name: 'string',
+      description: 'string',
+      createDate: '2023-03-09T20:43:05.061+00:00',
+      modifyDate: '2023-03-09T20:43:05.061+00:00',
+      username: null,
+    }) as { success: true; data: Project };
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/plugins/orion/src/models/project.ts
+++ b/plugins/orion/src/models/project.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const projectSchema = z.object({
   id: z.string(),
   name: z.string(),
-  description: z.string(),
+  description: z.string().nullable(),
   createDate: z.string().transform(Date),
   modifyDate: z.string().transform(Date),
   username: z.string().nullable(),

--- a/plugins/orion/src/models/project.ts
+++ b/plugins/orion/src/models/project.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const projectSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  createDate: z.string().transform(Date),
+  modifyDate: z.string().transform(Date),
+  username: z.string().nullable(),
+});
+
+export type Project = z.infer<typeof projectSchema>;

--- a/plugins/orion/src/models/workflow.test.ts
+++ b/plugins/orion/src/models/workflow.test.ts
@@ -1,0 +1,28 @@
+import { workflowSchema, type Workflow } from './workflow';
+
+describe('workflow', () => {
+  it('parses the workflow response', () => {
+    const result = workflowSchema.safeParse({
+      workFlowExecutionId: '5fecffb5-6425-478d-97c9-0f91e3b8da83',
+      workFlowOptions: {
+        currentVersion: null,
+        upgradeOptions: [],
+        migrationOptions: [],
+        newOptions: [
+          {
+            identifier: 'onboardingOption',
+            displayName: 'Onboarding',
+            description: 'An example of a complex WorkFlow',
+            details: ['An example of a complex WorkFlow with Status checks'],
+            workFlowName: 'onboardingWorkFlow_INFRASTRUCTURE_WORKFLOW',
+          },
+        ],
+        continuationOptions: [],
+        otherOptions: [],
+        optionsAvailable: false,
+      },
+    }) as { success: true; data: Workflow };
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/plugins/orion/src/models/workflow.ts
+++ b/plugins/orion/src/models/workflow.ts
@@ -24,3 +24,17 @@ export const workflowSchema = z.object({
 export type Workflow = z.infer<typeof workflowSchema>;
 
 export type WorkflowOptionItem = z.infer<typeof workflowOptionItem>;
+
+export type DisplayableOptions = Exclude<
+  keyof Workflow['workFlowOptions'],
+  'optionsAvailable' | 'currentVersion'
+>;
+
+export const displayableWorkflowOptions: readonly DisplayableOptions[] = [
+  'newOptions',
+  'upgradeOptions',
+  'continuationOptions',
+  'upgradeOptions',
+  'migrationOptions',
+  'otherOptions',
+] as const;

--- a/plugins/orion/src/models/workflow.ts
+++ b/plugins/orion/src/models/workflow.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const workflowOptionItem = z.object({
+  identifier: z.string(),
+  displayName: z.string(),
+  description: z.string(),
+  details: z.array(z.string()),
+  workFlowName: z.string(),
+});
+
+export const workflowSchema = z.object({
+  workFlowExecutionId: z.string(),
+  workFlowOptions: z.object({
+    currentVersion: workflowOptionItem.nullable(),
+    upgradeOptions: z.array(workflowOptionItem),
+    migrationOptions: z.array(workflowOptionItem),
+    newOptions: z.array(workflowOptionItem),
+    continuationOptions: z.array(workflowOptionItem),
+    otherOptions: z.array(workflowOptionItem),
+    optionsAvailable: z.boolean(),
+  }),
+});
+
+export type Workflow = z.infer<typeof workflowSchema>;
+
+export type WorkflowOptionItem = z.infer<typeof workflowOptionItem>;

--- a/plugins/orion/src/models/workflowDefinitionSchema.ts
+++ b/plugins/orion/src/models/workflowDefinitionSchema.ts
@@ -58,8 +58,3 @@ export type WorkFlowTaskParameter = z.infer<
 >;
 
 export type WorkFlowTaskParameterType = WorkFlowTaskParameter['type'];
-
-export type Project = Pick<
-  WorkflowDefinition,
-  'id' | 'name' | 'username' | 'description' | 'modifyDate'
->;

--- a/plugins/orion/src/urls.ts
+++ b/plugins/orion/src/urls.ts
@@ -1,4 +1,4 @@
-const path = '/api/proxy/parodos';
-export const Workflows = `${path}/workflows`;
-export const Projects = `${path}/projects`;
-export const WorkflowDefinitions = `${path}/workflowdefinitions`;
+const base = '/api/proxy/parodos';
+export const Workflows = `${base}/workflows`;
+export const Projects = `${base}/projects`;
+export const WorkflowDefinitions = `${base}/workflowdefinitions`;

--- a/plugins/orion/src/urls.ts
+++ b/plugins/orion/src/urls.ts
@@ -1,0 +1,4 @@
+const path = '/api/proxy/parodos';
+export const Workflows = `${path}/workflows`;
+export const Projects = `${path}/projects`;
+export const WorkflowDefinitions = `${path}/workflowdefinitions`;


### PR DESCRIPTION
After speaking with @RichardW98, a further POST to `/workflows` was needed after the project creation assessment POST.

The POST to `/workflows` returns workflow options and it is those that need rendered and not the workflow definitions.

This PR refactors to the above new requirements.

## Questions:
- Are we relying on all the workflow definitions being in memory or should an API call be made to retrieve the correct workflow definition?


 