### PR TITLE
Installation instructions for Parados Frontend plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,25 @@ To start the app, run:
 yarn install
 yarn dev
 ```
+
+## Local development
+
+For local development set the `PARODOS_AUTH_KEY` environment variable to 'Basic dGVzdDp0ZXN0'. This token is base64 encoded string containing `test:test`. You can also use `PARODOS_AUTH_KEY="Basic dGVzdDp0ZXN0" yarn dev` to start development environment with the test token. You can also create an `app-config.local.yaml` file with the following content to automatically include the token.
+
+```yaml
+proxy:
+  '/parodos':
+    headers:
+      Authorization: 'Basic dGVzdDp0ZXN0'
+```
+
+## Distribution
+
+### NPM Package
+
+To create an NPM package that can be installed via vendored dependencies, run `./scripts/build-orion.sh`. This will generate `success Wrote tarball to "/Users/tarasmankovski/Repositories/red-hat/backstage-orion/plugins/orion/parodos-plugin-orion-v0.1.0.tgz".` which gives you path to the generated `.tgz` file. 
+
+
+### Docker image
+
+To create a Docker image, run `./scripts/build-image.sh`. This will build a container and tag it with `backstage` you can push this image into the registry. For more information, checkout https://backstage.io/docs/deployment/docker

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -59,7 +59,7 @@ proxy:
     headers:
       Content-Type: 'application/json'
       accept: 'application/json'
-      Authorization: 'Basic dGVzdDp0ZXN0'
+      Authorization: ${PARODOS_AUTH_KEY}
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -5,6 +5,7 @@ import ExtensionIcon from '@material-ui/icons/Extension';
 import MapIcon from '@material-ui/icons/MyLocation';
 import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
+import MeetingRoomIcon from '@material-ui/icons/MeetingRoom';
 import LogoFull from './LogoFull';
 import LogoIcon from './LogoIcon';
 import {
@@ -69,6 +70,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
         <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
         <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
+        <SidebarItem icon={MeetingRoomIcon} to="/parodos" text="Parodos" />
         {/* End global nav */}
         <SidebarDivider />
         <SidebarScrollWrapper>

--- a/plugins/orion/README.md
+++ b/plugins/orion/README.md
@@ -63,3 +63,15 @@ proxy:
     headers:
       Authorization: 'Basic dGVzdDp0ZXN0'
 ```
+
+## Building Package
+
+To create an NPM package that can be installed via vendored dependencies, run the following commands.
+
+```bash
+yarn install
+yarn tsc
+yarn build:all
+yarn workspace @parodos/plugin-orion pack
+```
+

--- a/plugins/orion/README.md
+++ b/plugins/orion/README.md
@@ -4,10 +4,38 @@ Welcome to the parodos plugin!
 
 former name: Orion
 
-## Getting started
+## Setup
 
-Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/parodos](http://localhost:3000/parodos).
+1. Install the plugin into the Backstage app
 
-You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
-This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
-It is only meant for local development, and the setup for it can be found inside the [/dev](./dev) directory.
+```bash
+yarn add --cwd packages/app @parodos/plugin-orion
+```
+
+2.  Add the `/parodos/` route in `/packages/app/src/App.tsx`
+
+```ts
+import { OrionPage } from '@parodos/plugin-orion';
+
+const routes = (
+  <FlatRoutes>
+    // ...
+    <Route path="/parodos" element={<OrionPage />} />
+  </FlatRoutes>
+```
+
+3.  Add parodos endpoint to the proxy config in `app-config.yaml`.
+
+```yaml
+'/parodos':
+  target: 'http://localhost:8080/api/v1'
+  changeOrigin: true
+  redirect: follow
+  cache: 'no-cache'
+  headers:
+    Content-Type: 'application/json'
+    accept: 'application/json'
+    Authorization: ${PARODOS_AUTH_KEY}
+```
+
+For local development set the `PARODOS_AUTH_KEY` variable to the same value as in the `app-config.yaml`.

--- a/plugins/orion/README.md
+++ b/plugins/orion/README.md
@@ -63,14 +63,3 @@ proxy:
     headers:
       Authorization: 'Basic dGVzdDp0ZXN0'
 ```
-
-## Building Package
-
-To create an NPM package that can be installed via vendored dependencies, run the following commands.
-
-```bash
-yarn install
-yarn tsc
-yarn build:all
-yarn workspace @parodos/plugin-orion pack
-```

--- a/plugins/orion/README.md
+++ b/plugins/orion/README.md
@@ -6,13 +6,13 @@ former name: Orion
 
 ## Setup
 
-1. Install the plugin into the Backstage app
+1. Install the plugin into the Backstage app in `packages/app`
 
 ```bash
 yarn add --cwd packages/app @parodos/plugin-orion
 ```
 
-2.  Add the `/parodos/` route in `/packages/app/src/App.tsx`
+2. Add the `/parodos/` route in `/packages/app/src/App.tsx`
 
 ```ts
 import { OrionPage } from '@parodos/plugin-orion';
@@ -24,7 +24,22 @@ const routes = (
   </FlatRoutes>
 ```
 
-3.  Add parodos endpoint to the proxy config in `app-config.yaml`.
+3. Add `Parodos` link to the sidebar in `packages/app/src/components/Root.tsx`
+
+   3.1. Add `MeetingRoomIcon` import to the top of the file
+
+   ```tsx
+   import MeetingRoomIcon from '@material-ui/icons/MeetingRoom';
+   ```
+
+   3.2. Add `<SidebarItem icon={MeetingRoomIcon} to="/parodos" text="Parodos" />` after `Create...` icon. The result will look like this.
+
+   ```tsx
+   <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
+   <SidebarItem icon={MeetingRoomIcon} to="/parodos" text="Parodos" />
+   ```
+
+1. Add `/parodos` endpoint to the proxy config in `app-config.yaml`.
 
 ```yaml
 '/parodos':
@@ -38,4 +53,13 @@ const routes = (
     Authorization: ${PARODOS_AUTH_KEY}
 ```
 
-For local development set the `PARODOS_AUTH_KEY` variable to the same value as in the `app-config.yaml`.
+## Local development
+
+For local development set the `PARODOS_AUTH_KEY` environment variable to 'Basic dGVzdDp0ZXN0'. This token is base64 encoded string containing `test:test`. You can also use `PARODOS_AUTH_KEY="Basic dGVzdDp0ZXN0" yarn dev` to start development environment with the test token. You can also create an `app-config.local.yaml` file with the following content to automatically include the token.
+
+```yaml
+proxy:
+  '/parodos':
+    headers:
+      Authorization: 'Basic dGVzdDp0ZXN0'
+```

--- a/plugins/orion/README.md
+++ b/plugins/orion/README.md
@@ -74,4 +74,3 @@ yarn tsc
 yarn build:all
 yarn workspace @parodos/plugin-orion pack
 ```
-

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+yarn install
+yarn tsc
+
+export NODE_ENV=production
+
+yarn build:all
+
+yarn build-image

--- a/scripts/build-orion.sh
+++ b/scripts/build-orion.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+yarn install
+yarn tsc
+
+export NODE_ENV=production
+
+yarn build:all
+
+yarn workspace @parodos/plugin-orion pack


### PR DESCRIPTION
## Motivation

We need to start building a releasable version of the Parodos Orion plugin. A consumer of Parodos should be able to install an NPM package of the frontend plugin and use it.

## Approach

1. Added [README.md](https://github.com/thefrontside/backstage-orion/tree/pc/README/README.md) with instructions on how to install the plugin
2. Created [scripts/build-orion.sh](https://github.com/thefrontside/backstage-orion/blob/pc/README/scripts/build-orion.sh) to make it easier to build the bundle
3.  Created [scripts/build-image](https://github.com/thefrontside/backstage-orion/blob/pc/README/scripts/build-image.sh) to show how to properly build a container image
4. Here is the generated bundle https://github.com/thefrontside/parodos-install-test/blob/main/vendors/parodos-plugin-orion-v0.1.0.tgz
5. Here is an example of how to install generated bundle https://github.com/thefrontside/parodos-install-test/commit/01f758b916780b4dc53d6b31853b8b5746aa8bc1#diff-9fa008865bef344ab2f931a4ddf20163882b86ee764718adacf098dc19991946R53

## Verification

1. Created [perodos-install-test](https://github.com/thefrontside/parodos-install-test) repository to verify that Perodos Orion plugin installs from the generated bundle
2. Pushed a commit that show the entire installation process https://github.com/thefrontside/parodos-install-test/commit/01f758b916780b4dc53d6b31853b8b5746aa8bc1