### PR TITLE
split task name into friendly name

### DIFF
--- a/plugins/parodos/src/components/Form/Form.test.tsx
+++ b/plugins/parodos/src/components/Form/Form.test.tsx
@@ -61,9 +61,11 @@ describe('<Form />', () => {
     it('can submit the multi-step form', async () => {
       const onSubmit = jest.fn();
 
-      const { getByRole } = render(
+      const { getByRole, getByText } = render(
         <Form formSchema={formSchema} onSubmit={onSubmit} />,
       );
+
+      expect(getByText('Ad Group Work Flow Task')).toBeInTheDocument();
 
       await fireEvent.change(getByRole('textbox', { name: 'api-server' }), {
         target: { value: 'https://someurl.com' },

--- a/plugins/parodos/src/components/layouts/FluidObjectFieldTemplate.tsx
+++ b/plugins/parodos/src/components/layouts/FluidObjectFieldTemplate.tsx
@@ -56,7 +56,8 @@ export function FluidObjectFieldTemplate<
     properties.length === 1 &&
     uiSchema?.[properties[0].content.key as string]['ui:hidden'] === true;
 
-  const showTitle = uiSchema?.['ui:show-title'];
+  // TODO: reinstate when there is a task description
+  const showTitle = false; // uiSchema?.['ui:show-title'];
 
   return (
     <>

--- a/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema.ts
+++ b/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema.ts
@@ -14,6 +14,7 @@ import set from 'lodash.set';
 import get from 'lodash.get';
 import { type UiSchema } from '@rjsf/core';
 import type { JsonObject } from '@backstage/types';
+import { capitalize } from '../utils/string';
 
 export function getJsonSchemaType(type: WorkFlowTaskParameterType) {
   switch (type) {
@@ -93,7 +94,11 @@ export function jsonSchemaFromWorkflowDefinition(
   for (const task of workflowDefinition.tasks) {
     const schema: Record<string, any> = {
       type: 'object',
-      title: task.name,
+      title: task.name
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .split(' ')
+        .map(capitalize)
+        .join(' '), // TODO: task label would be good here
       properties: {},
       required: [],
     };

--- a/plugins/parodos/src/utils/string.ts
+++ b/plugins/parodos/src/utils/string.ts
@@ -1,0 +1,3 @@
+export function capitalize(text: string): string {
+  return `${text.charAt(0).toUpperCase()}${text.slice(1).toLowerCase()}`;
+}


### PR DESCRIPTION
split a task name like `adGroupWorkFlowTask` into:

![gg](https://user-images.githubusercontent.com/118328/225029388-04a0bfae-4704-451a-8136-f4c1bf5d3979.png)
