### PR TITLE
Introduce state management

### DIFF
--- a/plugins/parodos/package.json
+++ b/plugins/parodos/package.json
@@ -44,13 +44,14 @@
     "@rjsf/mui": "^5.2.0",
     "@rjsf/validator-ajv8": "^5.2.0",
     "assert-ts": "^0.3.4",
-    "classnames": "^2.3.2",
+    "immer": "^9.0.19",
     "lodash.set": "^4.3.2",
     "lodash.get": "^4.4.2",
-    "mobx": "^5.15.4",
-    "mobx-react": "^6.2.0",
+    "mobx": "^6.8.0",
+    "mobx-react": "^7.6.0",
     "react-use": "^17.2.4",
-    "zod": "^3.21.4"
+    "zod": "^3.21.4",
+    "zustand": "^4.3.6"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",

--- a/plugins/parodos/package.json
+++ b/plugins/parodos/package.json
@@ -37,7 +37,6 @@
     "@patternfly/react-icons": "^4.93.6",
     "@patternfly/react-styles": "^4.92.6",
     "@patternfly/react-topology": "^4.91.27",
-    "@rjsf/core": "^5.2.0",
     "@rjsf/material-ui-v5": "npm:@rjsf/material-ui@5.2.0",
     "@rjsf/utils": "^5.2.0",
     "@rjsf/core-v5": "npm:@rjsf/core@5.2.0",
@@ -47,14 +46,15 @@
     "immer": "^9.0.19",
     "lodash.set": "^4.3.2",
     "lodash.get": "^4.4.2",
-    "mobx": "^6.8.0",
-    "mobx-react": "^7.6.0",
+    "mobx": "^5.15.4",
+    "mobx-react": "^6.2.0",
     "react-use": "^17.2.4",
     "zod": "^3.21.4",
     "zustand": "^4.3.6"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-router-dom": "^6.8.1"
   },
   "devDependencies": {

--- a/plugins/parodos/src/components/App.tsx
+++ b/plugins/parodos/src/components/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useStore } from 'zustand';
+import { useStore } from '../stores/workflowStore/workflowStore';
 import { useBackendUrl } from './api/useBackendUrl';
 import { PluginRouter } from './PluginRouter';
 

--- a/plugins/parodos/src/components/App.tsx
+++ b/plugins/parodos/src/components/App.tsx
@@ -1,7 +1,23 @@
-import React from 'react';
-
+import React, { useEffect } from 'react';
+import { useStore } from 'zustand';
+import { useBackendUrl } from './api/useBackendUrl';
 import { PluginRouter } from './PluginRouter';
 
 export const App = () => {
+  const backendUrl = useBackendUrl();
+  const setBaseUrl = useStore(state => state.setBaseUrl);
+  const fetchProjects = useStore(state => state.fetchProjects);
+  const fetchDefinitions = useStore(state => state.fetchDefinitions);
+  
+  useEffect(() => {
+    setBaseUrl(backendUrl);
+  
+    async function initialiseStore() {
+      await Promise.all([fetchProjects(), fetchDefinitions()]);
+    }
+  
+    initialiseStore();
+  }, [backendUrl, fetchDefinitions, fetchProjects, setBaseUrl]);
+  
   return <PluginRouter />;
 };

--- a/plugins/parodos/src/components/App.tsx
+++ b/plugins/parodos/src/components/App.tsx
@@ -8,16 +8,16 @@ export const App = () => {
   const setBaseUrl = useStore(state => state.setBaseUrl);
   const fetchProjects = useStore(state => state.fetchProjects);
   const fetchDefinitions = useStore(state => state.fetchDefinitions);
-  
+
   useEffect(() => {
     setBaseUrl(backendUrl);
-  
+
     async function initialiseStore() {
       await Promise.all([fetchProjects(), fetchDefinitions()]);
     }
-  
+
     initialiseStore();
   }, [backendUrl, fetchDefinitions, fetchProjects, setBaseUrl]);
-  
+
   return <PluginRouter />;
 };

--- a/plugins/parodos/src/components/ParodosPage/ParodosPage.tsx
+++ b/plugins/parodos/src/components/ParodosPage/ParodosPage.tsx
@@ -1,15 +1,13 @@
-import React, { useCallback, useMemo, useState, type FC } from 'react';
+import React, { useCallback, useMemo, type FC } from 'react';
 import { Content, HeaderTabs, Page } from '@backstage/core-components';
 import { useLocation } from 'react-router-dom';
 import { PageHeader } from '../PageHeader';
-import type { ProjectType, PropsFromComponent } from '../types';
+import type { PropsFromComponent } from '../types';
 import { useNavigate } from 'react-router-dom';
-import { useBackendUrl } from '../api/useBackendUrl';
-import useAsync from 'react-use/lib/useAsync';
-import * as urls from '../../urls';
-import { ErrorMessage } from '../errors/ErrorMessage';
 import { TabLabel, TabLabelProps } from './TabLabel';
 import { navigationMap, pluginRoutePrefix } from './navigationMap';
+import { useStore } from '../../stores/workflowStore/workflowStore';
+import { ErrorMessage } from '../errors/ErrorMessage';
 
 // Unfortunately backstage do not export the props type for <Content />
 type ContentProps = PropsFromComponent<typeof Content>;
@@ -25,17 +23,9 @@ export const ParodosPage: FC<ParodosPageProps> = ({ children, ...props }) => {
       ),
     [pathname],
   );
-  // TODO: this should be coming from application state with mobx, recoil or something
-  const [hasProjects, setHasProjects] = useState(true);
-  const backendUrl = useBackendUrl();
+  const hasProjects = useStore(state => state.hasProjects());
+  const error = useStore(state => state.error());
   const navigate = useNavigate();
-
-  const { error } = useAsync(async () => {
-    const response = await fetch(`${backendUrl}${urls.Projects}`);
-
-    const receivedProjects = (await response.json()) as ProjectType[];
-    setHasProjects(receivedProjects.length > 0);
-  }, [backendUrl]);
 
   const tabs = useMemo(
     () =>
@@ -76,7 +66,7 @@ export const ParodosPage: FC<ParodosPageProps> = ({ children, ...props }) => {
         tabs={tabs}
       />
       <Content {...props}>
-        {error && <ErrorMessage error={error} />}
+        {error && <ErrorMessage error={error as Error} />}
         {children}
       </Content>
     </Page>

--- a/plugins/parodos/src/components/projectOverview/ProjectsTable.tsx
+++ b/plugins/parodos/src/components/projectOverview/ProjectsTable.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { ProjectType } from '../types';
 import { Table, TableColumn } from '@backstage/core-components';
 import {
   getHumanReadableDate,
   HumanReadableProjectStatus,
 } from '../converters';
+import { Project } from '../../models/project';
 
-export const ProjectsTable: React.FC<{ projects: ProjectType[] }> = ({
+export const ProjectsTable: React.FC<{ projects: Project[] }> = ({
   projects,
 }) => {
   const columns: TableColumn[] = [

--- a/plugins/parodos/src/components/projectOverview/ProjectsTable.tsx
+++ b/plugins/parodos/src/components/projectOverview/ProjectsTable.tsx
@@ -25,7 +25,7 @@ export const ProjectsTable: React.FC<{ projects: Project[] }> = ({
       modifyDate: getHumanReadableDate(project.modifyDate),
       status: project.status
         ? HumanReadableProjectStatus[project.status]
-        : undefined,
+        : 'In Progress',
     };
   });
 

--- a/plugins/parodos/src/components/workflow/Workflow.tsx
+++ b/plugins/parodos/src/components/workflow/Workflow.tsx
@@ -27,6 +27,7 @@ import {
   type WorkflowOptionsListItem,
 } from './WorkflowOptionsList';
 import { assert } from 'assert-ts';
+import { useStore } from '../../stores/workflowStore/workflowStore';
 
 const useStyles = makeStyles(theme => ({
   fullHeight: {
@@ -52,6 +53,7 @@ export function Workflow(): JSX.Element {
     WorkflowOptionsListItem[]
   >([]);
   const styles = useStyles();
+  const addProject = useStore(state => state.addProject);
 
   const { loading, error, value: formSchema } = useGetProjectAssessmentSchema();
 
@@ -111,14 +113,15 @@ export function Workflow(): JSX.Element {
 
       setWorkflowOptions(options);
 
+      addProject(newProject);
+
       setAssessmentStatus('complete');
     },
-    [backendUrl],
+    [addProject, backendUrl],
   );
 
   const errorApi = useApi(errorApiRef);
 
-  // TODO: we could generalise all errors if we used react-query
   useEffect(() => {
     if (error) {
       // eslint-disable-next-line no-console

--- a/plugins/parodos/src/components/workflow/useGetProjectAssessmentSchema.ts
+++ b/plugins/parodos/src/components/workflow/useGetProjectAssessmentSchema.ts
@@ -1,18 +1,15 @@
-import { type AsyncState } from 'react-use/lib/useAsync';
-import { useGetWorkflowDefinition } from '../../hooks/useGetWorkflowDefinitions';
 import { FormSchema } from '../types';
 import { jsonSchemaFromWorkflowDefinition } from '../../hooks/useWorkflowDefinitionToJsonSchema/jsonSchemaFromWorkflowDefinition';
 import { ASSESSMENT_WORKFLOW } from './constants';
 import { WorkflowDefinition } from '../../models/workflowDefinitionSchema';
+import { useStore } from '../../stores/workflowStore/workflowStore';
 
-export function useGetProjectAssessmentSchema(): AsyncState<FormSchema> {
-  const result = useGetWorkflowDefinition(ASSESSMENT_WORKFLOW, 'byName');
+export function useGetProjectAssessmentSchema(): FormSchema {
+  const definition = useStore(state =>
+    state.getWorkDefinitionBy('byName', ASSESSMENT_WORKFLOW),
+  );
 
-  if (!result.value) {
-    return { ...result, value: undefined };
-  }
-
-  const cloned = JSON.parse(JSON.stringify(result.value)) as WorkflowDefinition;
+  const cloned = JSON.parse(JSON.stringify(definition)) as WorkflowDefinition;
 
   // TODO: this should be coming from the API
   cloned.works[0].parameters?.unshift({
@@ -24,5 +21,5 @@ export function useGetProjectAssessmentSchema(): AsyncState<FormSchema> {
 
   const formSchema = jsonSchemaFromWorkflowDefinition(cloned);
 
-  return { ...result, value: formSchema };
+  return formSchema;
 }

--- a/plugins/parodos/src/components/workflow/workflowDetail/WorkFlowDetail.tsx
+++ b/plugins/parodos/src/components/workflow/workflowDetail/WorkFlowDetail.tsx
@@ -11,12 +11,12 @@ import { WorkFlowStepper } from './topology/WorkFlowStepper';
 import { useLocation, useParams } from 'react-router-dom';
 import { mockLog } from './topology/mock/mockLog';
 import * as urls from '../../../urls';
-import { useBackendUrl } from '../../api';
 import {
   WorkflowStatus,
   WorkflowTask,
   WorkStatus,
 } from '../../../models/workflowTaskSchema';
+import { useStore } from '../../../stores/workflowStore/workflowStore';
 
 const useStyles = makeStyles(_theme => ({
   container: {
@@ -46,7 +46,7 @@ export const WorkFlowDetail = () => {
   const [allTasks, setAllTasks] = useState<WorkflowTask[]>(initTasks);
   const [log, setLog] = useState<string>(``);
   const [countlog, setCountlog] = useState<number>(0);
-  const backendUrl = useBackendUrl();
+  const workflowsUrl = useStore(store => store.getApiUrl(urls.Workflows));
   const styles = useStyles();
 
   const getSelectedTaskLog = React.useCallback(
@@ -75,9 +75,7 @@ export const WorkFlowDetail = () => {
     };
 
     const updateWorkflowExecutionState = async () => {
-      const data = await fetch(
-        `${backendUrl}${urls.Workflows}/${executionId}/status`,
-      );
+      const data = await fetch(`${workflowsUrl}/${executionId}/status`);
 
       const response = (await data.json()) as WorkflowStatus;
 
@@ -90,7 +88,7 @@ export const WorkFlowDetail = () => {
     }, 5000);
 
     return () => clearInterval(taskInterval);
-  }, [allTasks, backendUrl, executionId]);
+  }, [allTasks, executionId, workflowsUrl]);
 
   // update log of selected task regularly
   useEffect(() => {

--- a/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema/useWorkflowDefinitionToJsonSchema.ts
+++ b/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema/useWorkflowDefinitionToJsonSchema.ts
@@ -1,36 +1,19 @@
-import {
-  GetDefinitionFilter,
-  useGetWorkflowDefinition,
-} from '../useGetWorkflowDefinitions';
 import { workflowDefinitionSchema } from '../../models/workflowDefinitionSchema';
-import { assert } from 'assert-ts';
 import type { FormSchema } from '../../components/types';
-import { type AsyncState } from 'react-use/lib/useAsync';
 import { jsonSchemaFromWorkflowDefinition } from './jsonSchemaFromWorkflowDefinition';
+import { GetDefinitionFilter } from '../../stores/types';
+import { useStore } from '../../stores/workflowStore/workflowStore';
 
 export function useWorkflowDefinitionToJsonSchema(
   workflowDefinition: string,
   filterType: GetDefinitionFilter,
-): AsyncState<FormSchema> {
-  const result = useGetWorkflowDefinition(workflowDefinition, filterType);
+): FormSchema {
+  const getWorkDefinitionBy = useStore(state => state.getWorkDefinitionBy);
+  const definition = getWorkDefinitionBy(filterType, workflowDefinition);
 
-  if (!result.value) {
-    return { ...result, value: undefined };
-  }
-
-  const { value: definition } = result;
-
-  const parseResult = workflowDefinitionSchema.safeParse(definition);
-
-  if (result.error) {
-    return { loading: false, error: result.error, value: undefined };
-  }
-
-  assert(parseResult.success, `workflowDefinitionSchema parse failed.`);
-
-  const { data: raw } = parseResult;
+  const raw = workflowDefinitionSchema.parse(definition);
 
   const formSchema = jsonSchemaFromWorkflowDefinition(raw);
 
-  return { value: formSchema, loading: false, error: undefined };
+  return formSchema;
 }

--- a/plugins/parodos/src/models/project.ts
+++ b/plugins/parodos/src/models/project.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+const projectStatus = z.union([
+  z.literal('in-progress'),
+  z.literal('on-boarded'),
+]);
+
 export const projectSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -7,6 +12,7 @@ export const projectSchema = z.object({
   createDate: z.string().transform(Date),
   modifyDate: z.string().transform(Date),
   username: z.string().nullable(),
+  status: projectStatus.nullable().optional(),
 });
 
 export type Project = z.infer<typeof projectSchema>;

--- a/plugins/parodos/src/stores/slices/projectsSlice.ts
+++ b/plugins/parodos/src/stores/slices/projectsSlice.ts
@@ -1,0 +1,24 @@
+import type { StateCreator } from 'zustand';
+import type {
+  ProjectsSlice,
+  State,
+  StateMiddleware,
+} from '../types';
+import * as urls from '../../urls';
+
+export const createProjectsSlice: StateCreator<
+  State,
+  StateMiddleware,
+  [],
+  ProjectsSlice
+> = (set, get) => ({
+  projects: [],
+  async fetch() {
+    const response = await fetch(`${get().baseUrl}${urls.Projects}`);
+    const projects = await response.json();
+
+    set(state => {
+      state.projects = projects;
+    });
+  },
+});

--- a/plugins/parodos/src/stores/slices/projectsSlice.ts
+++ b/plugins/parodos/src/stores/slices/projectsSlice.ts
@@ -1,10 +1,7 @@
 import type { StateCreator } from 'zustand';
-import type {
-  ProjectsSlice,
-  State,
-  StateMiddleware,
-} from '../types';
+import type { ProjectsSlice, State, StateMiddleware } from '../types';
 import * as urls from '../../urls';
+import { unstable_batchedUpdates } from 'react-dom';
 
 export const createProjectsSlice: StateCreator<
   State,
@@ -12,13 +9,36 @@ export const createProjectsSlice: StateCreator<
   [],
   ProjectsSlice
 > = (set, get) => ({
+  projectsLoading: false,
+  projectsError: undefined,
+  hasProjects() {
+    return get().projects.length > 0;
+  },
   projects: [],
-  async fetch() {
-    const response = await fetch(`${get().baseUrl}${urls.Projects}`);
-    const projects = await response.json();
-
+  async fetchProjects() {
     set(state => {
-      state.projects = projects;
+      state.workflowLoading = true;
+    });
+
+    try {
+      const response = await fetch(`${get().baseUrl}${urls.Projects}`);
+      const projects = await response.json();
+
+      set(state => {
+        unstable_batchedUpdates(() => {
+          state.projects = projects;
+          state.projectsLoading = false;
+        });
+      });
+    } catch (e) {
+      set(state => {
+        state.workflowError = e;
+      });
+    }
+  },
+  addProject(project) {
+    set(state => {
+      state.projects.push(project);
     });
   },
 });

--- a/plugins/parodos/src/stores/slices/uiSlice.ts
+++ b/plugins/parodos/src/stores/slices/uiSlice.ts
@@ -8,6 +8,9 @@ export const createUISlice: StateCreator<
   UISlice
 > = (set, get) => ({
   baseUrl: '',
+  getApiUrl(url: string) {
+    return `${get().baseUrl}${url}`;
+  },
   setBaseUrl(url) {
     set(state => {
       state.baseUrl = url;

--- a/plugins/parodos/src/stores/slices/uiSlice.ts
+++ b/plugins/parodos/src/stores/slices/uiSlice.ts
@@ -1,20 +1,22 @@
 import type { StateCreator } from 'zustand';
-import type {
-  UISlice,
-  StateMiddleware,
-  State,
-} from '../types';
+import type { UISlice, StateMiddleware, State } from '../types';
 
 export const createUISlice: StateCreator<
   State,
   StateMiddleware,
   [],
   UISlice
-> = set => ({
+> = (set, get) => ({
   baseUrl: '',
   setBaseUrl(url) {
     set(state => {
       state.baseUrl = url;
-    });
+    }, false);
+  },
+  loading() {
+    return get().projectsLoading || get().workflowLoading;
+  },
+  error() {
+    return get().workflowError ?? get().projectsError;
   },
 });

--- a/plugins/parodos/src/stores/slices/uiSlice.ts
+++ b/plugins/parodos/src/stores/slices/uiSlice.ts
@@ -1,0 +1,20 @@
+import type { StateCreator } from 'zustand';
+import type {
+  UISlice,
+  StateMiddleware,
+  State,
+} from '../types';
+
+export const createUISlice: StateCreator<
+  State,
+  StateMiddleware,
+  [],
+  UISlice
+> = set => ({
+  baseUrl: '',
+  setBaseUrl(url) {
+    set(state => {
+      state.baseUrl = url;
+    });
+  },
+});

--- a/plugins/parodos/src/stores/slices/workflowSlice.ts
+++ b/plugins/parodos/src/stores/slices/workflowSlice.ts
@@ -1,0 +1,24 @@
+import type { StateCreator } from 'zustand';
+import type {
+  StateMiddleware,
+  WorkflowSlice,
+  State,
+} from '../types';
+import * as urls from '../../urls';
+
+export const createWorkflowSlice: StateCreator<
+  State,
+  StateMiddleware,
+  [],
+  WorkflowSlice
+> = (set, get) => ({
+  workflowDefinitions: [],
+  async fetch() {
+    const response = await fetch(`${get().baseUrl}${urls.Projects}`);
+    const projects = await response.json();
+
+    set(state => {
+      state.projects = projects;
+    });
+  },
+});

--- a/plugins/parodos/src/stores/slices/workflowSlice.ts
+++ b/plugins/parodos/src/stores/slices/workflowSlice.ts
@@ -1,5 +1,10 @@
 import type { StateCreator } from 'zustand';
-import type { StateMiddleware, WorkflowSlice, State } from '../types';
+import {
+  type StateMiddleware,
+  type WorkflowSlice,
+  type State,
+  predicates,
+} from '../types';
 import * as urls from '../../urls';
 import { unstable_batchedUpdates } from 'react-dom';
 
@@ -12,6 +17,13 @@ export const createWorkflowSlice: StateCreator<
   workflowDefinitions: [],
   workflowLoading: false,
   workflowError: undefined,
+  getWorkDefinitionBy(filterBy, value) {
+    const workflowDefinition = get().workflowDefinitions.find(
+      def => predicates[filterBy](def) === value,
+    );
+
+    return workflowDefinition;
+  },
   async fetchDefinitions() {
     set(state => {
       state.workflowLoading = true;

--- a/plugins/parodos/src/stores/types.ts
+++ b/plugins/parodos/src/stores/types.ts
@@ -2,18 +2,27 @@ import type { Project } from '../models/project';
 import type { WorkflowDefinition } from '../models/workflowDefinitionSchema';
 
 export interface UISlice {
-  baseUrl: string;
+  baseUrl: string | undefined;
   setBaseUrl(url: string): void;
+  loading(): boolean;
+  error(): unknown | undefined;
 }
 
 export interface WorkflowSlice {
   workflowDefinitions: WorkflowDefinition[];
-  fetch(): Promise<void>;
+  fetchDefinitions(): Promise<void>;
+  // TODO: find a pattern that will allow loading and error on each slice
+  workflowLoading: boolean;
+  workflowError: unknown | undefined;
 }
 
 export interface ProjectsSlice {
   projects: Project[];
-  fetch(): Promise<void>;
+  fetchProjects(): Promise<void>;
+  hasProjects(): boolean;
+  addProject(project: Project): void;
+  projectsLoading: boolean;
+  projectsError: Error | undefined;
 }
 
 export type StateMiddleware = [

--- a/plugins/parodos/src/stores/types.ts
+++ b/plugins/parodos/src/stores/types.ts
@@ -6,12 +6,24 @@ export interface UISlice {
   setBaseUrl(url: string): void;
   loading(): boolean;
   error(): unknown | undefined;
+  getApiUrl(url: string): string;
 }
+
+export const predicates = {
+  byId: (workflow: WorkflowDefinition) => workflow.id,
+  byType: (workflow: WorkflowDefinition) => workflow.type,
+  byName: (workflow: WorkflowDefinition) => workflow.name,
+} as const;
+
+export type GetDefinitionFilter = keyof typeof predicates;
 
 export interface WorkflowSlice {
   workflowDefinitions: WorkflowDefinition[];
+  getWorkDefinitionBy(
+    filterBy: GetDefinitionFilter,
+    value: string,
+  ): WorkflowDefinition | undefined;
   fetchDefinitions(): Promise<void>;
-  // TODO: find a pattern that will allow loading and error on each slice
   workflowLoading: boolean;
   workflowError: unknown | undefined;
 }

--- a/plugins/parodos/src/stores/types.ts
+++ b/plugins/parodos/src/stores/types.ts
@@ -1,0 +1,24 @@
+import type { Project } from '../models/project';
+import type { WorkflowDefinition } from '../models/workflowDefinitionSchema';
+
+export interface UISlice {
+  baseUrl: string;
+  setBaseUrl(url: string): void;
+}
+
+export interface WorkflowSlice {
+  workflowDefinitions: WorkflowDefinition[];
+  fetch(): Promise<void>;
+}
+
+export interface ProjectsSlice {
+  projects: Project[];
+  fetch(): Promise<void>;
+}
+
+export type StateMiddleware = [
+  ['zustand/immer', never],
+  ['zustand/devtools', never],
+];
+
+export type State = UISlice & WorkflowSlice & ProjectsSlice;

--- a/plugins/parodos/src/stores/workflowStore/workflowStore.ts
+++ b/plugins/parodos/src/stores/workflowStore/workflowStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
-import { devtools } from 'zustand/middleware/devtools';
+import { devtools } from 'zustand/middleware';
 import { createProjectsSlice } from '../slices/projectsSlice';
 import { State } from '../types';
 import { createUISlice } from '../slices/uiSlice';

--- a/plugins/parodos/src/stores/workflowStore/workflowStore.ts
+++ b/plugins/parodos/src/stores/workflowStore/workflowStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { devtools } from 'zustand/middleware/devtools';
+import { createProjectsSlice } from '../slices/projectsSlice';
+import { State } from '../types';
+import { createUISlice } from '../slices/uiSlice';
+import { createWorkflowSlice } from '../slices/workflowSlice';
+
+export const useStore = create<State>()(
+  devtools(
+    immer((...args) => ({
+      ...createUISlice(...args),
+      ...createProjectsSlice(...args),
+      ...createWorkflowSlice(...args),
+    })),
+  ),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9422,7 +9422,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@^2.2.6, classnames@^2.3.1, classnames@^2.3.2:
+classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
@@ -13482,7 +13482,7 @@ ignore@^5.1.4, ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-immer@^9.0.1, immer@^9.0.7:
+immer@^9.0.1, immer@^9.0.19, immer@^9.0.7:
   version "9.0.19"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.19.tgz#67fb97310555690b5f9cd8380d38fc0aabb6b38b"
   integrity sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==
@@ -16467,6 +16467,11 @@ mobx-react-lite@^2.2.0:
   resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-2.2.2.tgz#87c217dc72b4e47b22493daf155daf3759f868a6"
   integrity sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg==
 
+mobx-react-lite@^3.4.0:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.4.3.tgz#3a4c22c30bfaa8b1b2aa48d12b2ba811c0947ab7"
+  integrity sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg==
+
 mobx-react@^6.2.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.3.1.tgz#204f9756e42e19d91cb6598837063b7e7de87c52"
@@ -16474,10 +16479,22 @@ mobx-react@^6.2.0:
   dependencies:
     mobx-react-lite "^2.2.0"
 
+mobx-react@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-7.6.0.tgz#ebf0456728a9bd2e5c24fdcf9b36e285a222a7d6"
+  integrity sha512-+HQUNuh7AoQ9ZnU6c4rvbiVVl+wEkb9WqYsVDzGLng+Dqj1XntHu79PvEWKtSMoMj67vFp/ZPXcElosuJO8ckA==
+  dependencies:
+    mobx-react-lite "^3.4.0"
+
 mobx@^5.15.4:
   version "5.15.7"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.15.7.tgz#b9a5f2b6251f5d96980d13c78e9b5d8d4ce22665"
   integrity sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw==
+
+mobx@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.8.0.tgz#59051755fdb5c8a9f3f2e0a9b6abaf86bab7f843"
+  integrity sha512-+o/DrHa4zykFMSKfS8Z+CPSEg5LW9tSNGTuN8o6MF1GKxlfkSHSeJn5UtgxvPkGgaouplnrLXCF+duAsmm6FHQ==
 
 mock-fs@^5.1.0:
   version "5.2.0"
@@ -21561,7 +21578,7 @@ use-resize-observer@^8.0.0:
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
 
-use-sync-external-store@^1.2.0:
+use-sync-external-store@1.2.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
@@ -22457,6 +22474,13 @@ zod@~3.18.0:
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.18.0.tgz#2eed58b3cafb8d9a67aa2fee69279702f584f3bc"
   integrity sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==
+
+zustand@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.6.tgz#ce7804eb75361af0461a2d0536b65461ec5de86f"
+  integrity sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==
+  dependencies:
+    use-sync-external-store "1.2.0"
 
 zwitch@^2.0.0:
   version "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6061,38 +6061,6 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.0.tgz#2c91791a9ba6ca0a0f4aaac5e45d58df13639ac8"
   integrity sha512-IgMK9i3sFGNUqPMbjABm0G26g0QCKCUBfglhQ7rQq6WcxbKfEHRcmwsoER4hZcuYqJgkYn2OeuoJIv7Jsftp7g==
 
-"@parodos/plugin-parodos@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@parodos/plugin-parodos/-/plugin-parodos-0.1.0.tgz#34aebd4732e9148afde87a831d94876e69e7495f"
-  integrity sha512-pzc/U0GpaDH/4KtabuduUQ3zpTWjSS2F9hVMhFk4kfEXoy6QUqSv/AKsyLhKwH7N225jBJfvqKrR6lgSdeU4Gw==
-  dependencies:
-    "@backstage/core-components" "^0.12.4"
-    "@backstage/core-plugin-api" "^1.4.0"
-    "@backstage/theme" "^0.2.17"
-    "@backstage/types" "^1.0.2"
-    "@emotion/react" "^11.10.6"
-    "@emotion/styled" "^11.10.6"
-    "@material-ui/core" "^4.12.2"
-    "@material-ui/icons" "^4.9.1"
-    "@material-ui/lab" "4.0.0-alpha.57"
-    "@mui/icons-material" "^5.11.11"
-    "@mui/material" "^5.11.12"
-    "@patternfly/react-core" "^4.276.6"
-    "@patternfly/react-icons" "^4.93.6"
-    "@patternfly/react-styles" "^4.92.6"
-    "@patternfly/react-topology" "^4.91.27"
-    "@rjsf/core" "^5.2.0"
-    "@rjsf/core-v5" "npm:@rjsf/core@5.2.0"
-    "@rjsf/material-ui-v5" "npm:@rjsf/material-ui@5.2.0"
-    "@rjsf/mui" "^5.2.0"
-    "@rjsf/utils" "^5.2.0"
-    "@rjsf/validator-ajv8" "^5.2.0"
-    assert-ts "^0.3.4"
-    mobx "^5.15.4"
-    mobx-react "^6.2.0"
-    react-use "^17.2.4"
-    zod "^3.21.4"
-
 "@patternfly/react-core@^4.276.6":
   version "4.276.6"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.6.tgz#fa39aa61022f70bf350b2efc660bdeb096bda447"
@@ -6245,7 +6213,7 @@
     nanoid "^3.3.4"
     prop-types "^15.7.2"
 
-"@rjsf/core-v5@npm:@rjsf/core@5.2.0", "@rjsf/core@^5.2.0":
+"@rjsf/core-v5@npm:@rjsf/core@5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.2.0.tgz#5adaa8a9c666c76a94b39065797bf23ce8bf0e2f"
   integrity sha512-Kj9NBD3Fu5hk1czB7ZreORHvmbOwFH2+3xnfJWERW/+MupV2RsMIyiah2Aa7UQsxymLmvLPaUIWpgx5IAW+dsQ==
@@ -8276,7 +8244,7 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     "@backstage/theme" "^0.2.17"
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"
-    "@parodos/plugin-parodos" "^0.1.0"
+    "@parodos/plugin-parodos" "^0.2.0"
     history "^5.0.0"
     react "^17.0.2"
     react-dom "^17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16467,11 +16467,6 @@ mobx-react-lite@^2.2.0:
   resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-2.2.2.tgz#87c217dc72b4e47b22493daf155daf3759f868a6"
   integrity sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg==
 
-mobx-react-lite@^3.4.0:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.4.3.tgz#3a4c22c30bfaa8b1b2aa48d12b2ba811c0947ab7"
-  integrity sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg==
-
 mobx-react@^6.2.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.3.1.tgz#204f9756e42e19d91cb6598837063b7e7de87c52"
@@ -16479,22 +16474,10 @@ mobx-react@^6.2.0:
   dependencies:
     mobx-react-lite "^2.2.0"
 
-mobx-react@^7.6.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-7.6.0.tgz#ebf0456728a9bd2e5c24fdcf9b36e285a222a7d6"
-  integrity sha512-+HQUNuh7AoQ9ZnU6c4rvbiVVl+wEkb9WqYsVDzGLng+Dqj1XntHu79PvEWKtSMoMj67vFp/ZPXcElosuJO8ckA==
-  dependencies:
-    mobx-react-lite "^3.4.0"
-
 mobx@^5.15.4:
   version "5.15.7"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.15.7.tgz#b9a5f2b6251f5d96980d13c78e9b5d8d4ce22665"
   integrity sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw==
-
-mobx@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.8.0.tgz#59051755fdb5c8a9f3f2e0a9b6abaf86bab7f843"
-  integrity sha512-+o/DrHa4zykFMSKfS8Z+CPSEg5LW9tSNGTuN8o6MF1GKxlfkSHSeJn5UtgxvPkGgaouplnrLXCF+duAsmm6FHQ==
 
 mock-fs@^5.1.0:
   version "5.2.0"


### PR DESCRIPTION
I've introduced some state management to reduce the number of API calls and enable sharing state across components that can be retrieved with simple selectors.

I've used [zustand](https://github.com/pmndrs/zustand) which is very light weight and does not have a lot of the baggage of some of the other state management packages.

I can talk through this if it is unclear.
